### PR TITLE
# теперь все условия (валидации, видимости и обязательности) использу…

### DIFF
--- a/protools_form_full.json
+++ b/protools_form_full.json
@@ -547,7 +547,7 @@
       },
       "customBuilding": {
         "param": "buildingLabel",
-        "xpath": "building.title"
+        "xpath": "building_custom.address"
       }
     },
     "visible-condition": {
@@ -559,6 +559,27 @@
         },
         {
           "hasNoAddress": false
+        },
+        {
+          "$or": [
+            {
+              "$and": [
+                {
+                  "city.hasStreetlessBuilding": false
+                },
+                {
+                  "street.id": {
+                    "$length": {
+                      "$gt": 0
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "city.hasStreetlessBuilding": true
+            }
+          ]
         }
       ]
     },
@@ -2928,7 +2949,19 @@
       }
     },
     "required-condition": true,
-    "visible-condition": true
+    "visible-condition": true,
+    "valid-conditions": [
+      {
+        "condition": {
+          "companyName": {
+            "$length": {
+              "$lte": 60
+            }
+          }
+        },
+        "errorMessage": "Не более 60 символов"
+      }
+    ]
   },
   {
     "title": "Контактное лицо",
@@ -2941,7 +2974,19 @@
       }
     },
     "required-condition": false,
-    "visible-condition": true
+    "visible-condition": true,
+    "valid-conditions": [
+      {
+        "condition": {
+          "contactName": {
+            "$length": {
+              "$lte": 40
+            }
+          }
+        },
+        "errorMessage": "Не более 40 символов"
+      }
+    ]
   },
   {
     "title": "Телефон",

--- a/pt_realty_form_schema.json
+++ b/pt_realty_form_schema.json
@@ -179,7 +179,7 @@
           "$ref": "#/definitions/simpleCondition"
         },
         {
-          "$ref": "#/definitions/inCondition"
+          "$ref": "#/definitions/pathValidationCondition"
         },
         {
           "$ref": "#/definitions/explicitCondition"
@@ -214,26 +214,6 @@
       "maxProperties": 1,
       "minProperties": 1
     },
-    "inCondition": {
-      "type": "object",
-      "minProperties": 1,
-      "maxProperties": 1,
-      "patternProperties": {
-        "^[a-zA-Z_]+(\\.{1}[a-zA-Z_]+)*$": {
-          "type": "object",
-          "properties": {
-            "$in": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/scalar"
-              }
-            }
-          },
-          "additionalProperties": false
-        }
-      },
-      "additionalProperties": false
-    },
     "simpleCondition": {
       "type": "object",
       "minProperties": 1,
@@ -248,7 +228,7 @@
     "validationRule": {
       "properties": {
         "condition": {
-          "$ref": "#/definitions/validationCondition"
+          "$ref": "#/definitions/someCondition"
         },
         "errorMessage": {
           "type": "string"
@@ -256,30 +236,6 @@
       },
       "minProperties": 2,
       "additionalProperties": false
-    },
-    "validationCondition": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/pathValidationCondition"
-        },
-        {
-          "$ref": "#/definitions/multipleValidationCondition"
-        }
-      ]
-    },
-    "multipleValidationCondition": {
-      "type": "object",
-      "properties": {
-        "$and": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/validationCondition"
-          }
-        }
-      },
-      "additionalProperties": false,
-      "minProperies": 1,
-      "maxProperies": 1
     },
     "pathValidationCondition": {
       "type": "object",
@@ -289,7 +245,7 @@
         "^[a-zA-Z_]+(\\.{1}[a-zA-Z_]+)*$": {
           "oneOf": [
             {
-              "$ref": "#/definitions/eqCondition"
+              "$ref": "#/definitions/pathCondition"
             },
             {
               "$ref": "#/definitions/typeCondition"
@@ -312,27 +268,43 @@
       },
       "additionalProperties": false
     },
-    "eqCondition": {
-      "type": "object",
-      "patternProperties": {
-        "\\$(ge|le|gt|lt)": {
-          "$ref": "#/definitions/eqOperand"
-        }
-      },
-      "additionalProperties": false
-    },
-    "eqOperand": {
+    "pathConditionOperand": {
       "oneOf": [
         {
-          "type": "number"
-        },
-        {
-          "$ref": "#/definitions/aliasPath"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/aliasPath"
+            },
+            {
+              "$ref": "#/definitions/scalar"
+            }
+          ]
         },
         {
           "$ref": "#/definitions/aggregate"
         }
       ]
+    },
+    "pathCondition": {
+      "type": "object",
+      "patternProperties": {
+        "\\$(gte|lte|gt|lt|eq)$": {
+          "$ref": "#/definitions/pathConditionOperand"
+        },
+        "\\$in$": {
+          "type":"array",
+          "minItems":2,
+          "items":{
+              "$ref": "#/definitions/pathConditionOperand"
+          }
+        },
+        "\\$length$": {
+          "$ref": "#/definitions/pathCondition"
+        }
+      },
+      "additionalProperties": false,
+      "maxProperties": 1,
+      "minProperties": 1
     },
     "aggregate": {
       "type": "object",
@@ -340,12 +312,14 @@
         "$sum": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/aliasPath"
+            "$ref": "#/definitions/pathConditionOperand"
           },
           "minItems": 2
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "maxProperties": 1,
+      "minProperties": 1
     },
     "aliasPath": {
       "type": "string",


### PR DESCRIPTION
- теперь все условия (валидации, видимости и обязательности) используют единый набор операторов
- отрефакторил оператор $in
- вмерджил поддержку $gt, $gte,$lt, $lte, $eq
- вмерджил поддержку операторов агрегации (пока только $sum)
- поддерживаются сложные комбинации условий, например 

``` json
{"ob1.title":{"$length":{"$gte":{"$sum":["object.value",42]}}}}
```
